### PR TITLE
[work in progress] Updates to email template

### DIFF
--- a/apps/mailman/templates/mailman/survey_email_html.py
+++ b/apps/mailman/templates/mailman/survey_email_html.py
@@ -32,7 +32,7 @@ def write_html(email_text, link_html):
         <td>&nbsp;</td>
         <td colspan="3" align="left" valign="top" style="color:#666666; font-size: 13px;">
             
-                <p> <pre>""" + email_text + """ </pre> </p>
+                <p>""" + email_text + """</p>
             
         </td>
         <td>&nbsp;</td>

--- a/apps/mailman/templates/mailman/survey_email_html.py
+++ b/apps/mailman/templates/mailman/survey_email_html.py
@@ -6,63 +6,42 @@ def write_html(email_text, link_html):
 <body style="margin:0; padding: 0;">
 <div align="center">
 <table border="0" cellpadding="0" cellspacing="0" align="center" width="100%" style="font-family: Arial,Helvetica,sans-serif; max-width: 700px;">
-       <tbody><tr bgcolor="#39446f">
-           <td colspan="5" height="40">&nbsp;</td>
-       </tr>
-           <tr bgcolor="#39446f"></tr>
-       <tr bgcolor="#39446f">
-           <td width="20">&nbsp;</td>
-           <td width="20">&nbsp;</td>
-           <td align="center" style="font-size: 29px; color:#FFF; font-weight: normal; letter-spacing: 1px; line-height: 1;
-                           text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.2); font-family: Arial,Helvetica,sans-serif;">
-    <img alt="WorkElections" src="https://s3.amazonaws.com/voteworker/workelections.png">
-        <br><br>
-              WorkElections.com Request for Information
-           </td>
-           <td width="20">&nbsp;</td>
-           <td width="20">&nbsp;</td>
-       </tr>
-       <tr bgcolor="#39446f">
-           <td colspan="5" height="40">&nbsp;</td>
-       </tr>   
-       <tr>
-           <td height="20" colspan="5">&nbsp;</td>
-       </tr>
-    <tr>
+    <tbody><tr>
+       <td align="center" style="padding-left:30px; padding-right:30px"><img width="200" alt="WorkElections" src="https://s3.amazonaws.com/voteworker/workelections.png"></td>
+       <td align="center" style="padding-left:30px; padding-right:30px"><img width="240" alt="Fair Elections Center" src="https://www.workelections.com/graphics/meta/FairElectionsCenterLogo.png"></td>
         <td>&nbsp;</td>
-        <td colspan="3" align="left" valign="top" style="color:#666666; font-size: 13px;">
+    </tr>
+    <tr><td colspan="2" style="padding-top:50px; padding-bottom:20px"><hr></td></tr>
+    <tr>
+        <td colspan="2" align="left" valign="top" style="color:#555555; padding-left:30px; padding-right:30px; padding-bottom:20px;">
             
                 <p>""" + email_text + """</p>
             
         </td>
-        <td>&nbsp;</td>
     </tr>
-        <tr>
-            <td colspan="5" height="30">&nbsp;</td>
-        </tr>
-        <tr>
-            <td>&nbsp;</td>
-            <td colspan="3">
-                <table border="0" cellpadding="0" cellspacing="0" align="left"
-                    <tr>
-                        <td align="center" valign="center">""" + link_html + """
-                        </td>
-                    </tr>
-                </table>
-            </td>
-            <td>&nbsp;</td>
-        </tr>
-        <tr>
-            <td colspan="5" height="30">&nbsp;</td>
-        </tr>
-    <tr>
-        <td height="20" colspan="5">&nbsp;</td>
-    </tr>
-    <tr>
-        <td height="20" colspan="5">&nbsp;</td>
-    </tr> 
+    <tr><td colspan="4">""" + link_html + """</td></tr></tbody>
+    <tr><td colspan="4" align="center" style="padding:10px; background-color:#BBBBBB; color:white; font-size:12px">
+    1825 K St. NW  | Suite 450<br>
+    Washington DC 20006<br>
+    (202) 331-0114<br>
+    <a style="color:#A5002F" href="mailto:info@fairelectionscenter.org">info@fairelectionscenter.org</a><br>
+    </td></tr>
 </table>
 </div>
 </body>
 </html>
 """
+
+def write_button(url, label):
+    return '''
+<td style="padding:10px"><div><!--[if mso]>
+  <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://" style="height:42px;v-text-anchor:middle;width:130px;" arcsize="10%" stroke="f" fillcolor="#3AAEE0">
+    <w:anchorlock/>
+    <center>
+  <![endif]-->
+      <a href="''' + url + '''"
+style="background-color:#3AAEE0;border-radius:4px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:16px;font-weight:bold;line-height:42px;text-align:center;text-decoration:none;width:130px;-webkit-text-size-adjust:none;">''' + label + '''</a>
+  <!--[if mso]>
+    </center>
+  </v:roundrect>
+<![endif]--></div></td>'''


### PR DESCRIPTION
 * Send individual emails to recipients instead of a single mail with everyone on to: line
 * Add logos in header
 * Remove &lt;pre&gt; tags around email body so font is not monospace
 * Add a button for each jurisdiction link
 * Add a footer with contact info

Sample output HTML: https://drive.google.com/file/d/17_e0Gx86lDfYlWagsyG1qwFd_6zkCMX2/view?usp=sharing

Screenshot of current progress: 
<img width="759" alt="screen shot 2018-10-18 at 10 48 56 pm" src="https://user-images.githubusercontent.com/4331931/47195046-0fadc880-d328-11e8-87a7-e4da08b49f76.png">

Issues I ran into:
  * I don't have the right WorkElections logo because it's not uploaded anywhere, and the FairElections logo I used is not from a CDN (from the workelections.com site). I think it would be best if both images were uploaded to a CDN, but not sure how to make that happen
 * The urls in my html/text emails are broken since settings.SURVEY_MONKEY_URL_ is a dummy url with no '/' at the end. I assume it's set right in production?
 * I don't have a local mailserver, so I don't have a great way of testing that the html in my emails doesn't get mangled when it's sent and received by a mail client. Any ideas?
