### PR TITLE
Fix problems with text emails.

### DIFF
--- a/apps/mailman/mailer.py
+++ b/apps/mailman/mailer.py
@@ -86,9 +86,10 @@ class MailSurvey(object):
         self.from_email = settings.DEFAULT_FROM_EMAIL
         self.subject = subject
         self.to_email = recipients
+        self.email_text = email_text
         c = PlainTextMailConverter()
         c.feed(email_text)
-        self.email_text = c.get_data()
+        self.email_plaintext = c.get_data()
 
         link_text = ""
         link_html = '\n<table width="100%"><tbody>'
@@ -105,7 +106,7 @@ class MailSurvey(object):
             link_html += "<td></td>"
             linecount += 1
         link_html += "</tbody></table>"
-        self.context={'EmailText': self.email_text, 'SurveyLinkText': link_text}
+        self.context={'EmailText': self.email_plaintext, 'SurveyLinkText': link_text}
         self.html = write_html(self.email_text, link_html)
         self.text_template = get_template('mailman/survey_email_text.txt')
 

--- a/apps/mailman/templates/mailman/survey_email_text.txt
+++ b/apps/mailman/templates/mailman/survey_email_text.txt
@@ -1,3 +1,9 @@
 {{EmailText}}
 
 {{SurveyLinkText}}
+
+Fair Elections Center
+1825 K St. NW | Suite 450
+Washington DC 20006
+(202) 331-0114
+info@fairelectionscenter.org


### PR DESCRIPTION
I didn't look to closely at plaintext emails before, but @nayelipelayo tested them manually and ran into some issues. I took a deeper look and found:

* Setting `message.content_subtype = "html"` on `EmailMultiAlternatives` actually makes **both** the text-based email and the html email have `Content-Type: text/html;`. Removed this line, and now the html mail has that content-type, but the text mail has `Content-Type: text/plain;`.
* I didn't keep the text-based mail up to date with the HTML mail. I added the address to the text template.
* Since the new HTML mail is generated by a rich text editor, it has HTML that needs to be stripped. I implemented an HTMLParser which does the following:
  * Injects newlines for &lt;p&gt; and &lt;br&gt; tags
  * Injects links in parenthesis after link text
  * Strips all other HTML tags.