### PR TITLE
Improve searchbox results and ranking

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -182,7 +182,7 @@ class SearchViewSet(viewsets.ViewSet):
         if 'q' in request.GET:
 
             # jurisdictions
-            jurisdictions = Jurisdiction.objects.filter(state__is_active=True).extra(order_by=['name'])
+            jurisdictions = Jurisdiction.objects.extra(order_by=['name'])
 
             query = request.GET.get('q')
 

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -175,8 +175,6 @@ class SearchViewSet(viewsets.ViewSet):
     def list(self, request):
         response = []
         if 'q' in request.GET:
-                    # statees
-            # states = State.objects.order_by('name')
 
             # jurisdictions
             jurisdictions = Jurisdiction.objects.filter(state__is_active=True).extra(order_by=['name'])
@@ -205,15 +203,5 @@ class SearchViewSet(viewsets.ViewSet):
                         'state_id': jur.state.id,
                         'state_alpha': jur.state.alpha
                     })
-
-            # look for states
-            # filtered_states = states.filter(name__istartswith=query)
-            # if filtered_states:
-            #     for state in filtered_states:
-            #         response.append({
-            #             'type': 'state',
-            #             'id': state.id,
-            #             'name': state.name
-            #         })
 
         return Response(response, status=status.HTTP_200_OK)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -94,7 +94,7 @@ class PageViewSet(viewsets.ReadOnlyModelViewSet):
 
 class JurisdictionViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-    queryset = Jurisdiction.objects.filter(state__is_active=True)
+    queryset = Jurisdiction.objects.filter()
     serializer_class = JurisdictionSerializer
 
     @list_route()


### PR DESCRIPTION
This implements the consensus from https://github.com/developmentseed/work.vote/issues/81:
* Ranking should list jurisdictions that are an exact match for what the user typed first
* Geocoded results should be listed second, ranked as they are by Mapbox
* Limit to 5 geocoded results instead of 20
* We should include results from inactive jurisdictions, which go to a page explaining that we don't have info yet.

Also removes commented out state listings, as these won't be put back in.