### PR TITLE
Revert "Bump django from 1.8.6 to 1.11.23"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.11.23
+django==1.8.6
 django-secure==1.0.1
 psycopg2==2.7.1
 djangorestframework==3.3.0


### PR DESCRIPTION
Reverts developmentseed/api.work.vote#79

Logs show:
2019-11-25T07:06:03.046624+00:00 app[web.1]: from django.forms.widgets import flatatt
2019-11-25T07:06:03.046625+00:00 app[web.1]: ImportError: cannot import name 'flatatt'

Will revert and then look into.