### PR TITLE
Return an empty result when geometry is not found for a jurisdiction

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -107,8 +107,15 @@ class JurisdictionViewSet(viewsets.ReadOnlyModelViewSet):
     
     @detail_route()
     def geojson(self, request, pk):
-        geometry = self.queryset.get(pk=pk).geometry.geojson
-        return Response(json.loads(geometry))
+        try:
+          geometry = self.queryset.get(pk=pk).geometry.geojson
+          return Response(json.loads(geometry))
+        except Jurisdiction.DoesNotExist:
+          # We return an empty result to avoid a 500 for jurisdictions without
+          # geometry, but this will also result in an empty result for invalid
+          # jurisdiction IDs.
+          # See https://github.com/developmentseed/api.work.vote/issues/81.
+          return Response({})
 
     def get_serializer(self, *args, **kwargs):
         """


### PR DESCRIPTION
This is a straightforward change to return an empty result if a jurisdiction is not found when looking for geometry, as suggested in #81 .

However, I don't understand where the "Baltimore (City)" entry originally came from. I don't see that string anywhere in the data from https://github.com/developmentseed/data.work.vote. I wanted to fix this issue by adding a database entry for all valid jurisdictions, but as far as I can tell from the import code this should already be the case.