### PR TITLE
Prep for django 1.11.23 upgrade

### DIFF
--- a/apps/mailman/mailer.py
+++ b/apps/mailman/mailer.py
@@ -59,7 +59,7 @@ class MailMaker(object):
 
     def send(self):
         if self.context:
-            c = Context(self.context)
+            c = Context(self.context).flatten()
 
         text_content = self.text_template.render(c)
         html_content = self.html_template.render(c)
@@ -111,7 +111,7 @@ class MailSurvey(object):
     def send(self):
         if self.context:
             c = Context(self.context)
-        
+
         text_content = self.text_template.render(c)
         html_content = self.html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ python-binary-memcached==0.28.0
 django-bmemcached==0.2.3
 django-nose==1.4.6
 -e git+https://github.com/digi604/django-smart-selects.git@js-unlinting-fixes#egg=smart_selects
--e git://github.com/aljosa/django-tinymce.git@tinymce4#egg=tinymce4
+-e git://github.com/aljosa/django-tinymce.git@master#egg=master


### PR DESCRIPTION
Update tinymce to use master branch
Update mailer to flatten context to dict since passing Context is
deprecated.