### PR TITLE
Fix geojson response when no geometry.

### DIFF
--- a/apps/api/test_views.py
+++ b/apps/api/test_views.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.test import Client
+from jurisdiction.models import Jurisdiction, State
+
+
+class JurisdictionViewSetTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_jurisdiction_view(self):
+        ca = State.objects.create(name='California')
+        sf = Jurisdiction.objects.create(name='San Francisco', state=ca)
+        response = self.client.get('/jurisdictions/%d/' % sf.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'San Francisco County')
+
+    def test_missing_jurisdiction(self):
+        response = self.client.get('/jurisdictions/42/')
+        self.assertEqual(response.status_code, 404)
+        
+    def test_jurisdiction_geojson_view_no_geometry(self):
+        ca = State.objects.create(name='California')
+        sf = Jurisdiction.objects.create(name='San Francisco', state=ca)
+        response = self.client.get('/jurisdictions/%d/geojson/' % sf.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.content)

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -43,7 +43,9 @@ def searchZipcode(zipcode, jurisdictions):
 
 
 def geocode(address, jurisdictions, required_precision_km=1., limit=5):
-    """ Find jurisdictions that match a given address Identifies the coordinates of an address. It will ignore the input
+    """Find jurisdictions that match a given address.
+
+    Identifies the coordinates of an address. It will ignore the input
     if it is only digits and less than 5 digits. If the input is only 5 digits
     the function assumes that is is a zipcode and search for zipcodes
 
@@ -107,8 +109,10 @@ class JurisdictionViewSet(viewsets.ReadOnlyModelViewSet):
     
     @detail_route()
     def geojson(self, request, pk):
-        geometry = self.queryset.get(pk=pk).geometry.geojson
-        return Response(json.loads(geometry))
+        geometry = self.queryset.get(pk=pk).geometry
+        if not geometry:
+            return Response()
+        return Response(json.loads(geometry.geojson))
 
     def get_serializer(self, *args, **kwargs):
         """

--- a/apps/jurisdiction/test_admin.py
+++ b/apps/jurisdiction/test_admin.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test import Client
-from .models import Jurisdiction, State
+from jurisdiction.models import Jurisdiction, State
 
 
 class JurisdictionAdminTestCase(TestCase):


### PR DESCRIPTION
Previously this route throws exception, returns 500.  Now returns empty
status 200; should allow page to render correctly without geo image.