### PR TITLE
Bugfix JSON response for no geometry.

### DIFF
--- a/apps/api/test_views.py
+++ b/apps/api/test_views.py
@@ -1,3 +1,4 @@
+import json
 from django.test import TestCase
 from django.test import Client
 from jurisdiction.models import Jurisdiction, State
@@ -23,4 +24,4 @@ class JurisdictionViewSetTestCase(TestCase):
         sf = Jurisdiction.objects.create(name='San Francisco', state=ca)
         response = self.client.get('/jurisdictions/%d/geojson/' % sf.id)
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.content)
+        self.assertEqual(json.loads(response.content.decode('utf-8')), {})

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -111,7 +111,7 @@ class JurisdictionViewSet(viewsets.ReadOnlyModelViewSet):
     def geojson(self, request, pk):
         geometry = self.queryset.get(pk=pk).geometry
         if not geometry:
-            return Response()
+            return Response({})
         return Response(json.loads(geometry.geojson))
 
     def get_serializer(self, *args, **kwargs):


### PR DESCRIPTION
Response is supposed to be JSON, so empty is invalid.