### PR TITLE
Fix jurisdictions with multiple emails.

### DIFF
--- a/apps/jurisdiction/admin.py
+++ b/apps/jurisdiction/admin.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse
 from .models import Jurisdiction, State, SurveyEmail
-from mailman.mailer import MailSurvey
+from mailman import mailer
 
 
 class JurisdictionAdmin(admin.ModelAdmin):
@@ -66,22 +66,10 @@ def send_email(modeladmin, request, queryset):
             for jurisdiction in obj_list:
                 jurisdiction_list.append([jurisdiction.name, jurisdiction.pk])
             jurisdiction_list.sort(key=lambda x: x[0])
-
-            if ',' in email_req.recipients:
-                recipient_list = email_req.recipients.split(',')
-            elif '\r\n' in email_req.recipients:
-                recipient_list = email_req.recipients.split('\r\n')
-            elif '\n' in email_req.recipients:
-                recipient_list = email_req.recipients.split('\n')
-            elif ';' in email_req.recipients:
-                recipient_list = email_req.recipients.split(';')
-            else: #assume only one e-mail
-                recipient_list = [email_req.recipients]
-            
-            recipient_list = [item.strip(' ') for item in recipient_list]
+            recipient_list = mailer.clean_emails(email_req.recipients)
             
             # send email
-            mail = MailSurvey(
+            mail = mailer.MailSurvey(
                 jurisdiction_list, recipient_list, email_req.email_text,
                 subject=email_req.name)
             status = mail.send()

--- a/apps/mailman/test_mailer.py
+++ b/apps/mailman/test_mailer.py
@@ -15,3 +15,16 @@ class MailMakerTestCase(SimpleTestCase):
         mail_maker.send()
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [test_jurisdiction.email])
+
+    def test_mulitaddress_email(self):
+        email1 = 'admin1@jurisdiction.com'
+        email2 = 'admin2@jurisdiction.com'
+        test_jurisdiction = Jurisdiction(email='%s;%s' % (email1, email2))
+        mail_maker = mailer.MailMaker(
+            test_jurisdiction,
+            subject='Test application subject',
+        )
+        self.assertEqual(len(mail.outbox), 0)
+        mail_maker.send()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [email1, email2])


### PR DESCRIPTION
Makes it legal for jurisdiction.email to have multiple addresses
separated by semicolon or comma (or newline but hopefully don't do that).
Unifies handling of these between MailSurvey and MailMaker.

AFAICT we don't have a mechanism for validating jurisdiction.email that
comes from survey responses though, so possible these will include
invalid separators like "add1 OR add2".