### PR TITLE
Add "Notes" TextField to states.

### DIFF
--- a/apps/jurisdiction/migrations/0029_state_notes.py
+++ b/apps/jurisdiction/migrations/0029_state_notes.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0028_auto_20200410_0231'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='state',
+            name='notes',
+            field=models.TextField(verbose_name='Notes', blank=True, null=True),
+        ),
+    ]

--- a/apps/jurisdiction/models.py
+++ b/apps/jurisdiction/models.py
@@ -10,6 +10,7 @@ class State(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     is_active = models.BooleanField('Whether state is active', default=True)
+    notes = models.TextField('Notes', null=True, blank=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
This includes the models.py change and the DB migration (which must currently be run manually after deploy).

Separate PR for work.vote front end repo will add this to the state page.