### PR TITLE
Add training_note parameter for jurisdictions

### DIFF
--- a/apps/api/SurveyResponses/survey_responses.py
+++ b/apps/api/SurveyResponses/survey_responses.py
@@ -71,7 +71,12 @@ def update_db_responses(answer_dict, jurisdiction_id):
             elif q_no == 16:
                 j.interview = a[0]
             elif q_no == 17:
-                j.training = a[0]
+                # Is this an Other, please specify response
+                if "specify" in q_list[1]: 
+                    j.training_note = a
+                # In the case of a "Yes/No" answer
+                else:
+                    j.training = a[0]
             elif q_no == 18:
                 j.complete_training = a[0]
             elif q_no == 19:

--- a/apps/jurisdiction/admin.py
+++ b/apps/jurisdiction/admin.py
@@ -26,6 +26,7 @@ class JurisdictionAdmin(admin.ModelAdmin):
         'minimum_age', 'high_school_student',
         'full_day_req',
         'compensation',
+        'training', 'training_note',
         'complete_training', 'post_training_exam',
         'must_have_email',
         'how_obtained',

--- a/apps/jurisdiction/migrations/0032_auto_20200430_1633.py
+++ b/apps/jurisdiction/migrations/0032_auto_20200430_1633.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0031_auto_20200427_1034'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='jurisdiction',
+            name='training_note',
+            field=models.TextField(blank=True, verbose_name='Training specific notes', null=True),
+        ),
+        migrations.AlterField(
+            model_name='jurisdiction',
+            name='jurisdiction_link',
+            field=models.ForeignKey(to='jurisdiction.Jurisdiction', verbose_name='link a jurisdiction', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='jurisdiction',
+            name='jurisdiction_link_text',
+            field=models.CharField(blank=True, verbose_name='disambiguation notice', max_length=250, null=True),
+        ),
+    ]

--- a/apps/jurisdiction/models.py
+++ b/apps/jurisdiction/models.py
@@ -67,6 +67,7 @@ class Jurisdiction(models.Model):
         null=True, blank=True)
     interview = models.TextField('Interview requirement - Input: Y or N', null=True, blank=True)
     training = models.TextField('Training - Input: Y or N', null=True, blank=True)
+    training_note = models.TextField('Training specific notes', null=True, blank=True)
     complete_training = models.TextField('Complete training for each election? - Input: Y or N',
                                          null=True, blank=True)
     post_training_exam = models.TextField('Pass a post-training exam or assessment - Input: Y or N',


### PR DESCRIPTION
In question 17 in the surveys, a person can respond with additional training notes. However, our backend picks up two keys with "question 17" in the key name, and so doesn't distinguish between the boolean "Is there a training" and "Please specify notes".

This is the backend part of the solution where we add a training_note parameter to the model.