### PR TITLE
Add jurisdiction.trusted_notes, remove old notes.

### DIFF
--- a/apps/api/serializer.py
+++ b/apps/api/serializer.py
@@ -73,4 +73,4 @@ class JurisdictionSerializer(JurisdictionSummarySerializer):
 
     class Meta:
         model = Jurisdiction
-        exclude = ['geometry', 'notes', 'created_at', 'updated_at']
+        exclude = ['geometry', 'created_at', 'updated_at']

--- a/apps/jurisdiction/admin.py
+++ b/apps/jurisdiction/admin.py
@@ -30,7 +30,8 @@ class JurisdictionAdmin(admin.ModelAdmin):
         'complete_training', 'post_training_exam',
         'must_have_email',
         'how_obtained',
-        'notes', 'further_notes',
+        'further_notes',
+        'trusted_notes',
         'geometry',
     )
 
@@ -111,9 +112,7 @@ def get_csv_survey_links(modeladmin, request, queryset):
 
 
 class SurveyEmailAdmin(admin.ModelAdmin):
-    list_display = (
-        'name', 'send_email', 'recipients'
-    )
+    list_display = ('name', 'send_email', 'recipients')
     actions = [send_email, mark_unsent, get_csv_survey_links]
 
     def get_readonly_fields(self, request, obj=None):

--- a/apps/jurisdiction/migrations/0033_trusted_notes.py
+++ b/apps/jurisdiction/migrations/0033_trusted_notes.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import tinymce.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0032_auto_20200430_1633'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='jurisdiction',
+            name='notes',
+        ),
+        migrations.AddField(
+            model_name='jurisdiction',
+            name='trusted_notes',
+            field=tinymce.models.HTMLField(verbose_name='Notes (trusted content rendered without HTML escaping)', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='jurisdiction',
+            name='further_notes',
+            field=models.TextField(verbose_name='Further Notes (populated from survey responses)', null=True, blank=True),
+        ),
+    ]

--- a/apps/jurisdiction/models.py
+++ b/apps/jurisdiction/models.py
@@ -78,10 +78,10 @@ class Jurisdiction(models.Model):
     candidate_prohibition = models.TextField(
         'Prohibition on being a candidate or related to a candidate - Y or N',
         null=True, blank=True)
-    notes = models.TextField('Notes', null=True, blank=True)
     geometry = models.MultiPolygonField('Jurisdiction Geometry', null=True, blank=True)
     city = models.BooleanField('Whether the jurisdiction is a city', default=False)
-    further_notes = models.TextField('Further Notes', null=True, blank=True)
+    further_notes = models.TextField('Further Notes (populated from survey responses)', null=True, blank=True)
+    trusted_notes = HTMLField('Notes (trusted content rendered without HTML escaping)', null=True, blank=True)
     display = models.CharField(max_length = 1, choices = DISPLAY_OPTIONS, default='Y')
     student_website = models.CharField('Website for Student Pollworker Program', max_length=400, null=True, blank=True)
     jurisdiction_link = models.ForeignKey('self', blank=True, null=True, verbose_name='link a jurisdiction')


### PR DESCRIPTION
Removes obsolete jurisdiction.notes field.  Adds new HTMLField for
trusted_notes, intended for display on front end without HTML escaping.

Also note in description for jurisdiction.further_notes that this field
is typically populated from survey responses.