### PR TITLE
Add export action for Jurisdictions.

### DIFF
--- a/apps/jurisdiction/admin.py
+++ b/apps/jurisdiction/admin.py
@@ -4,6 +4,8 @@ from django.http import HttpResponse
 from .models import Jurisdiction, State, SurveyEmail
 from mailman import mailer
 from django import forms
+import import_export
+
 
 class JurisdictionAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
@@ -11,7 +13,15 @@ class JurisdictionAdminForm(forms.ModelForm):
         self.fields['jurisdiction_link'].widget = forms.TextInput()
 
 
-class JurisdictionAdmin(admin.ModelAdmin):
+class JurisdictionResource(import_export.resources.ModelResource):
+
+    class Meta:
+        model = Jurisdiction
+        exclude = 'geometry',
+
+
+class JurisdictionAdmin(import_export.admin.ExportActionModelAdmin):
+    resource_class = JurisdictionResource
     list_display = 'name', 'state', 'website', 'telephone', 'email', 'city'
     list_filter = 'state', 'city'
     fields = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -38,7 +38,8 @@ THIRD_PARTY_APPS = (
     'rest_framework.authtoken',
     'corsheaders',
     'smart_selects',
-    'tinymce'
+    'tinymce',
+    'import_export',
 )
 
 # Apps specific for this project go here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,6 @@ django-nose==1.4.6
 -e git+https://github.com/digi604/django-smart-selects.git@js-unlinting-fixes#egg=smart_selects
 -e git://github.com/aljosa/django-tinymce.git@tinymce4#egg=tinymce4
 django-import-export==1.2.0
+
+# This is the most recent version that is compatible with v1.x django-import-export.
 tablib==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ django-bmemcached==0.2.3
 django-nose==1.4.6
 -e git+https://github.com/digi604/django-smart-selects.git@js-unlinting-fixes#egg=smart_selects
 -e git://github.com/aljosa/django-tinymce.git@tinymce4#egg=tinymce4
+django-import-export==1.2.0
+tablib==0.14.0


### PR DESCRIPTION
Request from FEC to allow exporting Jurisdictions data.  This django-import-export plugin was a little brittle given that our Django version is old, but overall seems pretty good.