### PR TITLE
Feature/admin name overrides

### DIFF
--- a/apps/api/serializer.py
+++ b/apps/api/serializer.py
@@ -12,7 +12,7 @@ def format_jurisdiction_name(obj):
     if match:
         return obj.name
     if obj.city:
-        return '%s (City)' % obj.name
+        return '{} ({})'.format(obj.name, obj.city_label)
     else:
         return '{} {}'.format(obj.name, obj.state.subdivision_name)
 

--- a/apps/api/serializer.py
+++ b/apps/api/serializer.py
@@ -5,7 +5,7 @@ from pages.models import Page
 from jurisdiction.models import Jurisdiction, State
 
 
-def add_city_string(obj):
+def format_jurisdiction_name(obj):
     match = re.search(
             '(city|county|region|City|County|Region)',
             obj.name)
@@ -14,7 +14,7 @@ def add_city_string(obj):
     if obj.city:
         return '%s (City)' % obj.name
     else:
-        return '%s County' % obj.name
+        return '{} {}'.format(obj.name, obj.state.subdivision_name)
 
 
 class PageSerializer(serializers.ModelSerializer):
@@ -57,7 +57,7 @@ class JurisdictionSummarySerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         context = super(JurisdictionSummarySerializer, self).to_representation(instance)
-        context['name'] = add_city_string(instance)
+        context['name'] = format_jurisdiction_name(instance)
 
         return context
 

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -16,7 +16,7 @@ from rest_framework import viewsets, permissions, status
 from pages.models import Page
 from jurisdiction.models import State, Jurisdiction, Zipcode
 from jurisdiction.export import export_jurisdiction_emails
-from .serializer import (StateSerializer, JurisdictionSerializer, add_city_string, JurisdictionSummarySerializer,
+from .serializer import (StateSerializer, JurisdictionSerializer, format_jurisdiction_name, JurisdictionSummarySerializer,
                          PageSerializer)
 
 
@@ -212,7 +212,7 @@ class SearchViewSet(viewsets.ViewSet):
                     response.append({
                         'type': 'jurisdiction',
                         'id': jur.id,
-                        'name': add_city_string(jur),
+                        'name': format_jurisdiction_name(jur),
                         'state_id': jur.state.id,
                         'state_alpha': jur.state.alpha
                     })

--- a/apps/jurisdiction/admin.py
+++ b/apps/jurisdiction/admin.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from .models import Jurisdiction, State, SurveyEmail
 from mailman import mailer
 from django import forms
+from django.core.exceptions import ValidationError
 import import_export
 
 
@@ -12,6 +13,11 @@ class JurisdictionAdminForm(forms.ModelForm):
         super(JurisdictionAdminForm, self).__init__(*args, **kwargs)
         self.fields['jurisdiction_link'].widget = forms.TextInput()
 
+    def clean(self):
+        cleaned_data = super().clean()
+        print(cleaned_data)
+        if cleaned_data.get('city') and not cleaned_data.get('city_label'):
+            raise ValidationError('The local admin label should be set if the jurisdiction is a city')
 
 class JurisdictionResource(import_export.resources.ModelResource):
 
@@ -26,7 +32,7 @@ class JurisdictionAdmin(import_export.admin.ExportActionModelAdmin):
     list_filter = 'state', 'city'
     fields = (
         'name', 'state',
-        'display', 'city','jurisdiction_link', 'jurisdiction_link_text',
+        'display', 'city', 'city_label', 'jurisdiction_link', 'jurisdiction_link_text',
         'obtained_at',
         'website', 'application', 'student_website',
         'telephone', 'email',

--- a/apps/jurisdiction/migrations/0034_state_subdivision_name.py
+++ b/apps/jurisdiction/migrations/0034_state_subdivision_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0033_trusted_notes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='state',
+            name='subdivision_name',
+            field=models.CharField(default='County', max_length=250, verbose_name='Subdivision Name'),
+        ),
+    ]

--- a/apps/jurisdiction/migrations/0035_jurisdiction_city_label.py
+++ b/apps/jurisdiction/migrations/0035_jurisdiction_city_label.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0034_state_subdivision_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='jurisdiction',
+            name='city_label',
+            field=models.CharField(default='City', max_length=250, verbose_name='Label for local government unit'),
+        ),
+    ]

--- a/apps/jurisdiction/migrations/0036_auto_20200630_1419.py
+++ b/apps/jurisdiction/migrations/0036_auto_20200630_1419.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jurisdiction', '0035_jurisdiction_city_label'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='jurisdiction',
+            name='city_label',
+            field=models.CharField(default='City', blank=True, verbose_name='Label for local government unit (if city)', max_length=250),
+        ),
+    ]

--- a/apps/jurisdiction/models.py
+++ b/apps/jurisdiction/models.py
@@ -81,6 +81,7 @@ class Jurisdiction(models.Model):
         null=True, blank=True)
     geometry = models.MultiPolygonField('Jurisdiction Geometry', null=True, blank=True)
     city = models.BooleanField('Whether the jurisdiction is a city', default=False)
+    city_label = models.CharField('Label for local government unit (if city)', max_length=250, default='City', blank=True)
     further_notes = models.TextField('Further Notes (populated from survey responses)', null=True, blank=True)
     trusted_notes = HTMLField('Notes (trusted content rendered without HTML escaping)', null=True, blank=True)
     display = models.CharField(max_length = 1, choices = DISPLAY_OPTIONS, default='Y')
@@ -91,7 +92,7 @@ class Jurisdiction(models.Model):
     def __str__(self):
         city = ''
         if self.city:
-            city = ', (city)'
+            city = ', ({})'.format(self.city_label)
         return '{} , {} {}'.format(self.name,self.state.name,city)
 
 

--- a/apps/jurisdiction/models.py
+++ b/apps/jurisdiction/models.py
@@ -10,6 +10,7 @@ class State(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     is_active = models.BooleanField('Whether state is active', default=True)
+    subdivision_name = models.CharField('Subdivision Name', max_length=250, default='County')
     notes = models.TextField('Notes', null=True, blank=True)
 
     def __str__(self):

--- a/apps/survey/views.py
+++ b/apps/survey/views.py
@@ -9,7 +9,7 @@ from django.core.mail import send_mail
 
 from survey.models import Application, Survey
 from mailman.mailer import MailMaker
-from api.serializer import add_city_string
+from api.serializer import format_jurisdiction_name
 from jurisdiction.models import Jurisdiction
 from survey.export import export_applications, export_surveys
 
@@ -156,7 +156,7 @@ class ContactViewSet(viewsets.ViewSet):
                             status=status.HTTP_400_BAD_REQUEST)
 
         context = {
-            'jurisdiction_name': add_city_string(jurisdiction),
+            'jurisdiction_name': format_jurisdiction_name(jurisdiction),
             'first_name': data.get('first_name', None),
             'last_name': data.get('last_name', None),
             'city': data.get('city', None),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   makemigrations:
     <<: *base_django_setup
-    command: python manage.py makemigrations --merge
+    command: python manage.py makemigrations
   
   boundaries:
     <<: *base_django_setup


### PR DESCRIPTION
This adds two new label overrides:
- For a state, it allows the change from `County` to another subdivision name like `Parish`
- For a particular jurisdiction, it allows the change from `City` to something else like `Town`