### PR TITLE
Fix various email issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/developmentseed/api.work.vote.svg?style=svg)](https://circleci.com/gh/developmentseed/api.work.vote)
 
-This is the API for the Work the Elections project. The project is sponsored by the Knight Foundation is developed by the Development Seed and [FELN](http://fairelectionsnetwork.com/)
+This is the API for the Work the Elections project. The project is sponsored by the Knight Foundation is developed by the Development Seed and [FEC](http://fairelectionscenter.org/) (previously FELN).
 
 ## Local Installation
 

--- a/apps/api/SurveyResponses/survey_responses.py
+++ b/apps/api/SurveyResponses/survey_responses.py
@@ -105,7 +105,7 @@ def send_error_email(juris_no, juris_info):
         'WorkElections.com: Error on survey response import',
         'No data could be updated from the last survey response for Jurisdiction {}: {}, {}. Check whether the survey format has been changed.'.format(juris_no, juris_info[0], juris_info[1]),
         'info@workelections.com',
-        [settings.CONTACT_US],
+        [settings.ADMIN_EMAIL],
     )
 
 @csrf_exempt

--- a/apps/mailman/mailer.py
+++ b/apps/mailman/mailer.py
@@ -76,7 +76,6 @@ class MailMaker(object):
 
         msg = EmailMultiAlternatives(self.subject, text_content,
                                      self.from_email, self.to_emails)
-        msg.content_subtype = "html"
         msg.attach_alternative(html_content, "text/html")
         msg.send()
 
@@ -92,7 +91,7 @@ class MailSurvey(object):
         subject='WorkElections.com Survey',
         **kwargs
     ):
-        self.from_email = settings.DEFAULT_FROM_EMAIL
+        self.from_email = settings.DEFAULT_SURVEY_FROM_EMAIL
         self.subject = subject
         self.to_email = recipients
         self.email_text = email_text

--- a/apps/mailman/templates/mailman/text_template.txt
+++ b/apps/mailman/templates/mailman/text_template.txt
@@ -1,10 +1,10 @@
 The following information was provided at workelections.com by a person who is interested in serving as a poll worker in your jurisdiction.  Workelections.com is a nonpartisan project which has collected poll worker information and applications for hundreds of counties and other jurisdictions nationwide, making it easy for local election officials and potential workers to connect. Workelections.com does not retain the personal or contact information of any user submitting this form.
 
 
-For more information or if you have any questions, please go to workelections.com</a> or email us at info@fairelectionsnetwork.com. Thank you.
+For more information or if you have any questions, please go to workelections.com</a> or email us at info@fairelectionscenter.org. Thank you.
 
 -----------------------------
-Poll Worker Application for {{jurisdiction_name}}, {{jurisdiction.state.alpha}}
+Poll Worker Letter of Interest for {{jurisdiction_name}}, {{jurisdiction.state.alpha}}
 
 First Name: {{first_name|default_if_none:'Not provided'}}
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -95,7 +95,7 @@ EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND', default='django.core.mail.backends.s
 
 # MANAGER CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#admins
-ADMIN_EMAIL = env('ADMIN_EMAIL', default='test@example.com')
+ADMIN_EMAIL = env('ADMIN_EMAIL', default='info@fairelectionscenter.org')
 
 ADMINS = (
     ("""DevOps""", ADMIN_EMAIL),
@@ -106,8 +106,11 @@ MANAGERS = ADMINS
 # END MANAGER CONFIGURATION
 
 # Contact us email
-CONTACT_US = env('CONTACT_US', default='info@fairelectionsnetwork.com')
-DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='info@fairelectionsnetwork.com')
+CONTACT_US = env('CONTACT_US', default='info@fairelectionscenter.org')
+DEFAULT_FROM_EMAIL = env(
+    'DEFAULT_FROM_EMAIL', default='info@fairelectionscenter.org')
+DEFAULT_SURVEY_FROM_EMAIL = env(
+    'DEFAULT_SURVEY_FROM_EMAIL', default=DEFAULT_FROM_EMAIL)
 TEST_TO_EMAIL = env('TEST_TO_EMAIL', default=None)
 
 # DATABASE CONFIGURATION


### PR DESCRIPTION
Three main things:
  1. Fixed bug where context_subtype was set to html for the txt version
     of the generic letter of interest, which made them hard to read in some clients.
  2. Updated email FROM settings.
  3. Changed all references to info@fairelectionsnetwork.com to
     info@fairelectionscenter.org.

I also went ahead and updated the README to refer to FEC instead of
FELN.